### PR TITLE
Add webpack-bundle-analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "format-glob": "prettier --write",
     "ng": "ng",
     "build": "ng build",
+    "build:stats": "ng build --prod --stats-json",
+    "bundle-report": "webpack-bundle-analyzer dist/browser/stats.json",
     "prod": "http-server ./dist/browser -o -g",
     "build:prod": "ng build --target=production --environment=prod",
     "deploy": "ng build --prod --base-href /angular-starter/ && angular-cli-ghpages --no-silent --dir=dist/browser",
@@ -101,6 +103,7 @@
     "tslint": "5.11.0",
     "tslint-angular": "1.1.2",
     "typescript": "3.1.3",
+    "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "3.1.0"
   }
 }


### PR DESCRIPTION
This should allow us to easily analyze the bundle sizes and get a clear picture of what's taking up the most space for each bundle.

To use, first run `npm run build:stats`. When this is finished, run `npm run build-report`.