### PR TITLE
Fix chart label formatting for dates

### DIFF
--- a/src/app/libs/chart/chart.component.ts
+++ b/src/app/libs/chart/chart.component.ts
@@ -221,28 +221,24 @@ export class ChartComponent implements OnInit, OnChanges, AfterViewInit, OnDestr
         interval: 1,
         labelFontSize: this.styling.fontSize,
         labelFontFamily: this.styling.fontFamily,
-        labelFormatter: val => {
+        labelFormatter: (this.formatXLabels || this.showXAxisLabels === false) ? val => {
           if (this.showXAxisLabels === false) {
             return ''; // If show labels is disabled, return empty string which hides the labels
-          } else if (this.formatXLabels) {
-            return this.formatXLabels(val); // If custom formatter supplied, format strings
           }
-          return val.label; // Otherwise return default value
-        },
+          return this.formatXLabels(val); // If custom formatter supplied, format strings
+        } : null, // Otherwise return default value
       },
       axisY: {
         title: this.titleYAxis,
         titleFontSize: 16,
         labelFontSize: this.styling.fontSize,
         labelFontFamily: this.styling.fontFamily,
-        labelFormatter: val => {
+        labelFormatter: (this.formatYLabels || this.showYAxisLabels === false) ? val => {
           if (this.showYAxisLabels === false) {
             return ''; // If show labels is disabled, return empty string which hides the labels
-          } else if (this.formatYLabels) {
-            return this.formatYLabels(val); // If custom formatter supplied, format strings
           }
-          return val.value; // Otherwise return default value
-        },
+          return this.formatYLabels(val); // If custom formatter supplied, format strings
+        } : null, // Otherwise return default value
       },
     };
     // console.log(options)


### PR DESCRIPTION
When dates were used, `return val.label` would return null. The logic has been updated to only attempt to format the labels if they are disabled or if a formatter function is being provided. This allows the chart component to fall back to the native label format handling in all other cases.